### PR TITLE
fix: recognise options that are overwritten unnecessarily

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -2,6 +2,7 @@
 // This may require changes when upgrading to esbuild 0.17+
 
 const { build } = require("esbuild");
+const glob = require("glob");
 
 const baseConfig = {
 	bundle: true,
@@ -9,13 +10,15 @@ const baseConfig = {
 	sourcemap: process.env.NODE_ENV !== "production",
 };
 
+const testFiles = process.env.NODE_ENV !== "production" ? glob.sync("./src/test/**/*.ts") : [];
+
 const extensionConfig = {
 	...baseConfig,
 	platform: "node",
 	mainFields: ["module", "main"],
 	format: "cjs",
-	entryPoints: ["./src/extension.ts"],
-	outfile: "./out/extension.js",
+	entryPoints: ["./src/extension.ts", ...testFiles],
+	outdir: "./out",
 	external: ["vscode"],
 };
 

--- a/src/astUtils.ts
+++ b/src/astUtils.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import {
+	ArrayASTNode,
 	ASTNode,
 	Location,
 	ObjectASTNode,
@@ -123,4 +124,65 @@ export function getOptionsFromParamDefinition(
 			return typeof o.label === "string" && typeof o.value === "number";
 		});
 	return options;
+}
+
+export function isJSONDifferentToAST(json: unknown, ast: ASTNode): boolean {
+	const jsonType =
+		typeof json === "object"
+			? Array.isArray(json)
+				? "array"
+				: "object"
+			: typeof json;
+
+	if (jsonType !== ast.type) {
+		return true;
+	}
+
+	if (isArrayASTNode(ast) && Array.isArray(json)) {
+		const arrayASTNode = ast;
+		if (arrayASTNode.items.length !== json.length) {
+			return true;
+		}
+
+		for (let i = 0; i < arrayASTNode.items.length; i++) {
+			if (isJSONDifferentToAST(json[i], arrayASTNode.items[i])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	if (isObjectASTNode(ast) && typeof json === "object" && json !== null) {
+		if (ast.properties.length !== Object.keys(json).length) {
+			return true;
+		}
+
+		for (const property of ast.properties) {
+			if (!property.valueNode) {
+				return true;
+			}
+
+			if (
+				isJSONDifferentToAST(
+					(json as Record<string, unknown>)[property.keyNode.value],
+					property.valueNode,
+				)
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	return ast.value !== json;
+}
+
+export function isArrayASTNode(node: ASTNode): node is ArrayASTNode {
+	return node.type === "array";
+}
+
+export function isObjectASTNode(node: ASTNode): node is ObjectASTNode {
+	return node.type === "object";
 }

--- a/src/astUtils.ts
+++ b/src/astUtils.ts
@@ -134,18 +134,18 @@ export function isJSONDifferentToAST(json: unknown, ast: ASTNode): boolean {
 				: "object"
 			: typeof json;
 
+	// If the property is undefined in the JSON but present in the AST it will return here
 	if (jsonType !== ast.type) {
 		return true;
 	}
 
 	if (isArrayASTNode(ast) && Array.isArray(json)) {
-		const arrayASTNode = ast;
-		if (arrayASTNode.items.length !== json.length) {
+		if (ast.items.length !== json.length) {
 			return true;
 		}
 
-		for (let i = 0; i < arrayASTNode.items.length; i++) {
-			if (isJSONDifferentToAST(json[i], arrayASTNode.items[i])) {
+		for (let i = 0; i < ast.items.length; i++) {
+			if (isJSONDifferentToAST(json[i], ast.items[i])) {
 				return true;
 			}
 		}

--- a/src/diagnostics/importOverrideDiagnostics.ts
+++ b/src/diagnostics/importOverrideDiagnostics.ts
@@ -79,10 +79,10 @@ export function generateImportOverrideDiagnostics(
 		if (!block) continue;
 		const [imp, properties] = block;
 
-		for (const [name, value, propNode] of properties) {
+		for (const [name, valueNode, propNode] of properties) {
 			const originalValue = imp[name];
 
-			if (value && !isJSONDifferentToAST(originalValue, value)) {
+			if (valueNode && !isJSONDifferentToAST(originalValue, valueNode)) {
 				ret.push({
 					type: DiagnosticType.UnnecessaryImportOverride,
 					range: rangeFromNode(config.original, propNode.parent),
@@ -91,7 +91,7 @@ export function generateImportOverrideDiagnostics(
 				ret.push({
 					type: DiagnosticType.ImportOverride,
 					range: rangeFromNode(config.original, propNode),
-					value,
+					value: getPropertyValueFromNode(propNode),
 					originalValue,
 				});
 			}

--- a/src/test/suite/astUtils.test.ts
+++ b/src/test/suite/astUtils.test.ts
@@ -1,0 +1,384 @@
+import assert from "node:assert";
+import {
+	ArrayASTNode,
+	ASTNode,
+	ObjectASTNode,
+} from "vscode-json-languageservice";
+import { isJSONDifferentToAST } from "../../astUtils";
+
+suite("astUtils", () => {
+	suite("isJSONDifferentToAST", () => {
+		test("returns false if primitive values match", () => {
+			const ast = {
+				type: "number",
+				value: 5,
+			} as ASTNode;
+
+			const json = 5;
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, false);
+		});
+
+		test("returns true if AST is a number type and json is string", () => {
+			const ast = {
+				type: "number",
+				value: 5,
+			} as ASTNode;
+
+			const json = "5";
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if AST is object type and json is array", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = [5];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if AST is array type and json is object", () => {
+			const ast = {
+				type: "array",
+				items: [
+					{
+						type: "number",
+						value: 5,
+					},
+				],
+			} as ArrayASTNode;
+
+			const json = { 0: 5 };
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if value in array is different", () => {
+			const ast = {
+				type: "array",
+				items: [
+					{
+						type: "number",
+						value: 5,
+					},
+				],
+			} as ArrayASTNode;
+
+			const json = [6];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if ast array is longer than json array", () => {
+			const ast = {
+				type: "array",
+				items: [
+					{
+						type: "number",
+						value: 5,
+					},
+					{
+						type: "number",
+						value: 5,
+					},
+				],
+			} as ArrayASTNode;
+
+			const json = [5];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if ast array is longer than json array", () => {
+			const ast = {
+				type: "array",
+				items: [
+					{
+						type: "number",
+						value: 5,
+					},
+				],
+			} as ArrayASTNode;
+
+			const json = [5, 5];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if ast object has more properties than json object", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test2",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = { test: 5 };
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if json object has more properties than ast object", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = { test: 5, test2: 5 };
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if json object has different property to ast object", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = { test2: 5 };
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns true if json object has different value to ast object", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = { test: 6 };
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+
+		test("returns false if complex json matches ast", () => {
+			const ast = {
+				items: [
+					{
+						properties: [
+							{
+								keyNode: {
+									type: "string",
+									value: "test",
+								},
+								type: "property",
+								valueNode: {
+									type: "number",
+									value: 1,
+								},
+							},
+							{
+								keyNode: {
+									type: "string",
+									value: "test2",
+								},
+								type: "property",
+								valueNode: {
+									type: "array",
+									items: [
+										{
+											type: "object",
+											properties: [
+												{
+													keyNode: {
+														type: "string",
+														value: "innerTest",
+													},
+													type: "property",
+													valueNode: {
+														type: "boolean",
+														value: false,
+													},
+												},
+											],
+										},
+									],
+								},
+							},
+						],
+						type: "object",
+					},
+				],
+				type: "array",
+			} as ASTNode;
+
+			const json = [
+				{
+					test: 1,
+					test2: [
+						{
+							innerTest: false,
+						},
+					],
+				},
+			];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, false);
+		});
+
+		test("returns true if complex json differs from ast", () => {
+			const ast = {
+				items: [
+					{
+						properties: [
+							{
+								keyNode: {
+									type: "string",
+									value: "test",
+								},
+								type: "property",
+								valueNode: {
+									type: "number",
+									value: 1,
+								},
+							},
+							{
+								keyNode: {
+									type: "string",
+									value: "test2",
+								},
+								type: "property",
+								valueNode: {
+									type: "array",
+									items: [
+										{
+											type: "object",
+											properties: [
+												{
+													keyNode: {
+														type: "string",
+														value: "innerTest",
+													},
+													type: "property",
+													valueNode: {
+														type: "boolean",
+														// difference here
+														value: true,
+													},
+												},
+											],
+										},
+									],
+								},
+							},
+						],
+						type: "object",
+					},
+				],
+				type: "array",
+			} as ASTNode;
+
+			const json = [
+				{
+					test: 1,
+					test2: [
+						{
+							innerTest: false,
+						},
+					],
+				},
+			];
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
+	});
+});

--- a/src/test/suite/astUtils.test.ts
+++ b/src/test/suite/astUtils.test.ts
@@ -380,5 +380,30 @@ suite("astUtils", () => {
 
 			assert.strictEqual(result, true);
 		});
+
+		test("it returns true if the property is in AST but not in the JSON", () => {
+			const ast = {
+				type: "object",
+				properties: [
+					{
+						type: "property",
+						keyNode: {
+							type: "string",
+							value: "test",
+						},
+						valueNode: {
+							type: "number",
+							value: 5,
+						},
+					},
+				],
+			} as ObjectASTNode;
+
+			const json = undefined;
+
+			const result = isJSONDifferentToAST(json, ast);
+
+			assert.strictEqual(result, true);
+		});
 	});
 });

--- a/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
+++ b/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
@@ -20,7 +20,7 @@ suite("importOverrideDiagnostics", () => {
 	}
 
 	suite("generateImportOverrideDiagnostics", () => {
-		test("returns an importOverride if a property has been overridden with a differnt value", async () => {
+		test("returns an importOverride if a property has been overridden with a different value", async () => {
 			const documentContent = {
 				test_template: {
 					test: 1,
@@ -80,7 +80,7 @@ suite("importOverrideDiagnostics", () => {
 			);
 		});
 
-		test("returns an unnescessaryImportOverride if a property has been overridden with the same value", async () => {
+		test("returns an unnecessaryImportOverride if a property has been overridden with the same value", async () => {
 			const documentContent = {
 				test_template: {
 					test: 1,
@@ -106,7 +106,7 @@ suite("importOverrideDiagnostics", () => {
 			);
 		});
 
-		test("returns an unnescessaryImportOverride if an options property has been overridden with the same value", async () => {
+		test("returns an unnecessaryImportOverride if an options property has been overridden with the same value", async () => {
 			const documentContent = {
 				test_template: {
 					options: [

--- a/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
+++ b/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
@@ -1,0 +1,143 @@
+import * as assert from "node:assert";
+import { parseConfigDocument } from "../../../configDocument";
+import { generateImportOverrideDiagnostics } from "../../../diagnostics/importOverrideDiagnostics";
+
+import * as vscode from "vscode";
+import { getLanguageService as getJsonLanguageService } from "vscode-json-languageservice";
+import { DiagnosticType } from "../../../diagnostics/diagnostics";
+import { My } from "../../../my";
+
+suite("importOverrideDiagnostics", () => {
+	const languageService = getJsonLanguageService({});
+
+	async function setup(documentContent: object) {
+		const document = await vscode.workspace.openTextDocument({
+			language: "JSON",
+			content: JSON.stringify(documentContent),
+		});
+
+		return parseConfigDocument({ ls: languageService } as My, document);
+	}
+
+	suite("generateImportOverrideDiagnostics", () => {
+		test("returns an importOverride if a property has been overridden with a differnt value", async () => {
+			const documentContent = {
+				test_template: {
+					test: 1,
+				},
+				paramInformation: [
+					{
+						"#": 1,
+						$import: "#test_template",
+						test: 2,
+					},
+				],
+			};
+
+			const document = await setup(documentContent);
+
+			const result = generateImportOverrideDiagnostics(document);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(
+				result[0].type,
+				DiagnosticType.ImportOverride,
+				"Incorrect Diagnostic Type",
+			);
+		});
+
+		test("returns an importOverride if an options property has been overridden with a different value", async () => {
+			const documentContent = {
+				test_template: {
+					options: [
+						{
+							test: 1,
+						},
+					],
+				},
+				paramInformation: [
+					{
+						"#": 1,
+						$import: "#test_template",
+						options: [
+							{
+								test: 2,
+							},
+						],
+					},
+				],
+			};
+
+			const document = await setup(documentContent);
+
+			const result = generateImportOverrideDiagnostics(document);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(
+				result[0].type,
+				DiagnosticType.ImportOverride,
+				"Incorrect Diagnostic Type",
+			);
+		});
+
+		test("returns an unnescessaryImportOverride if a property has been overridden with the same value", async () => {
+			const documentContent = {
+				test_template: {
+					test: 1,
+				},
+				paramInformation: [
+					{
+						"#": 1,
+						$import: "#test_template",
+						test: 1,
+					},
+				],
+			};
+
+			const document = await setup(documentContent);
+
+			const result = generateImportOverrideDiagnostics(document);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(
+				result[0].type,
+				DiagnosticType.UnnecessaryImportOverride,
+				"Incorrect Diagnostic Type",
+			);
+		});
+
+		test("returns an unnescessaryImportOverride if an options property has been overridden with the same value", async () => {
+			const documentContent = {
+				test_template: {
+					options: [
+						{
+							test: 1,
+						},
+					],
+				},
+				paramInformation: [
+					{
+						"#": 1,
+						$import: "#test_template",
+						options: [
+							{
+								test: 1,
+							},
+						],
+					},
+				],
+			};
+
+			const document = await setup(documentContent);
+
+			const result = generateImportOverrideDiagnostics(document);
+
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(
+				result[0].type,
+				DiagnosticType.UnnecessaryImportOverride,
+				"Incorrect Diagnostic Type",
+			);
+		});
+	});
+});

--- a/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
+++ b/src/test/suite/diagnostics/importOverrideDiagnostics.test.ts
@@ -139,5 +139,32 @@ suite("importOverrideDiagnostics", () => {
 				"Incorrect Diagnostic Type",
 			);
 		});
+
+		test("returns an importOverride if a property is overwritten", async () => {
+			const documentContent = {
+				test_template: {
+					testProperty: 5,
+				},
+				paramInformation: [
+					{
+						"#": 1,
+						$import: "#test_template",
+						testProperty: 7,
+					},
+				],
+			};
+
+			const document = await setup(documentContent);
+
+			const result = generateImportOverrideDiagnostics(document) as any;
+
+			assert.strictEqual(result.length, 1);
+			assert.deepStrictEqual(
+				result[0].type,
+				DiagnosticType.ImportOverride,
+			);
+			assert.deepStrictEqual(result[0].value, 7);
+			assert.deepStrictEqual(result[0].originalValue, 5);
+		});
 	});
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,5 +1,5 @@
-import * as glob from "glob";
-import * as Mocha from "mocha";
+import glob from "glob";
+import Mocha from "mocha";
 import path from "path";
 
 export function run(): Promise<void> {


### PR DESCRIPTION
### Changes:

- Add new util function to compare JSON to AST `isJSONDifferentToAST`.
- Use `isJSONDifferentToAST` function to compare changes after edit.
- Add test files to build when not in production
- Correct import of `Mocha` and `Glob` in test suite

fixes: https://github.com/zwave-js/zwave-js/issues/7811

Options have been overwritten and one of the properties is different, only indicates that the property is overwritten:

![image](https://github.com/user-attachments/assets/716123ac-be4d-4047-8d48-5244af1dd7a2)


Options have been overwritten and all of the properties are the same, shows as an error:

![image](https://github.com/user-attachments/assets/749076f0-37c2-4f4c-9685-c08954971d9b)

(^^ I created these examples by changing the `master_template`, those changes are not included in the PR)